### PR TITLE
Fix

### DIFF
--- a/src/render.mo
+++ b/src/render.mo
@@ -243,6 +243,7 @@ module {
         bitmap(bdf c, bta);
         end()
       };
+      end()
     };
 
     public func end() {


### PR DESCRIPTION
Found a missing `end()` that was causing assertion failure downstream, in an app.

Need more tests here.