### PR TITLE
feat: EventInfo, with datetimes, and nonce

### DIFF
--- a/src/Types.mo
+++ b/src/Types.mo
@@ -21,6 +21,13 @@ module {
 
   public module Event {
 
+    public type EventInfo = {
+      nonce: ?Nat;
+      dateTimeUtc: Text;   // use [ISO8601](https://tools.ietf.org/html/rfc3339)
+      dateTimeLocal: Text; // use [ISO8601](https://tools.ietf.org/html/rfc3339)
+      event: Event;
+    };
+
     public type Event = {
       #quit;
       #keyDown : [KeyInfo];


### PR DESCRIPTION
- local date time
- utc date time
- date time as strings, using https://tools.ietf.org/html/rfc3339
- optional https://en.wikipedia.org/wiki/Cryptographic_nonce